### PR TITLE
Skip spilling float args when `%al==0`

### DIFF
--- a/src/abi/sysv.c
+++ b/src/abi/sysv.c
@@ -1,3 +1,4 @@
+#include "compiler_c/analyse/analysis_types.h"
 #ifdef __linux__
 
 #include <compiler_c/abi/abi.h>
@@ -294,21 +295,30 @@ void abi_gen_params(IR_Context *ctx, IR_Function *f) {
                                                     .ops = {[0] = ir_stack_value(8, 8, -8 * (INTEGER_PARAM_REGISTERS - i) - 128)},
                                                     .param = {.param_index = i, .type = type_u64}});
         }
-        // TODO: Skip if float spill if (al == 0)
-        // testb %al, %al
-        // je after floats block
-        // use movaps
+        IR_Value al_equal_zero = ir_cmp(ctx, EQ,
+                                        (IR_Value){.kind = IR_PHYS_REG,
+                                                   .size = 8,
+                                                   .align = 8,
+                                                   .phys_reg =
+                                                       (PhysReg){
+                                                           .kind = REG_GP,
+                                                           .gp_reg = RAX,
+                                                           .data_kind = REG_DATA_NONE,
+                                                           .size = REG_8,
+                                                       }},
+                                        ir_integer_literal(0), type_u8);
+
+        IR_Block *skip_floats_block = ir_new_block();
+        ir_branch_cond(ctx, al_equal_zero, skip_floats_block, NULL);
+
+        // Todo use movaps or move this to x86 lowering
         for (int i = floats_emitted; i < FLOAT_PARAM_REGISTERS; i++) {
             ir_append_instruction(ctx->block, &(IR_Instruction){.op = IR_PARAM,
                                                                 .op_count = 1,
                                                                 .ops = {[0] = ir_stack_value(8, 8, -16 * (FLOAT_PARAM_REGISTERS - i))},
                                                                 .param = {.param_index = i, .type = type_f64}});
         }
-        // assume va_list is allocated to store gp_offset, fp_offset, overflow_arg_area, reg_save_area
-        // gp_offset = offset in bytes from reg_save_area to the next gp variable (+8 each va_arg call with type != T_FLOAT)
-        // sse_offset = offset in bytes from reg_save_area to the next sse variable (+8 each va_arg call with type == T_FLOAT)
-        // reg_save_area = leaq -176(%rbp)
-        // overflow_arg_area = lea 16(%rbp)
+        ir_append_block(ctx, skip_floats_block);
     }
 }
 

--- a/tests/test.c
+++ b/tests/test.c
@@ -1,4 +1,13 @@
-int main() {
-    char a[] = "\xAa";
-    return a[0];
+#include <stdarg.h>
+int sum(int n, ...) {
+    va_list ap;
+    va_start(ap, n);
+    int sum = 0;
+    for (int i = 0; i < n; i++) {
+        sum += va_arg(ap, int);
+    }
+    va_end(ap);
+    return sum;
 }
+
+int main() { return sum(5, 1, 2, 3, 4, 5); }

--- a/tests/test.s
+++ b/tests/test.s
@@ -1,37 +1,198 @@
 .section .note.GNU-stack,"",@progbits
-.section .rodata
-.LC0:
-    .byte 0xAA, 0
 
 .text
+.global sum
+sum:
+    push %rbp
+    mov %rsp, %rbp
+    subq $272, %rsp
+sum_0:
+    movl %edi, -184(%rbp)
+    movq %rsi, -168(%rbp)
+    movq %rdx, -160(%rbp)
+    movq %rcx, -152(%rbp)
+    movq %r8, -144(%rbp)
+    movq %r9, -136(%rbp)
+    movb %al, %al
+    cmpb $0, %al
+    sete %al
+    movzbl %al, %eax
+    movl %eax, -232(%rbp)
+    movl -232(%rbp), %eax
+    testl %eax, %eax
+    jnz sum_1
+    movsd %xmm0, -128(%rbp)
+    movsd %xmm1, -112(%rbp)
+    movsd %xmm2, -96(%rbp)
+    movsd %xmm3, -80(%rbp)
+    movsd %xmm4, -64(%rbp)
+    movsd %xmm5, -48(%rbp)
+    movsd %xmm6, %xmm0
+    movsd %xmm0, -32(%rbp)
+    movsd %xmm7, %xmm0
+    movsd %xmm0, -16(%rbp)
+sum_1:
+    leaq -208(%rbp), %rax
+    movq %rax, -232(%rbp)
+    movq -232(%rbp), %rax
+    movl $8, %ecx
+    movl %ecx, (%rax)
+    movq -232(%rbp), %rax
+    addq $4, %rax
+    movq %rax, -232(%rbp)
+    movq -232(%rbp), %rax
+    movl $48, %ecx
+    movl %ecx, (%rax)
+    movq -232(%rbp), %rax
+    addq $4, %rax
+    movq %rax, -232(%rbp)
+    leaq 16(%rbp), %rax
+    movq %rax, -240(%rbp)
+    movq -232(%rbp), %rax
+    movq -240(%rbp), %rcx
+    movq %rcx, (%rax)
+    movq -232(%rbp), %rax
+    addq $8, %rax
+    movq %rax, -232(%rbp)
+    leaq -176(%rbp), %rax
+    movq %rax, -240(%rbp)
+    movq -232(%rbp), %rax
+    movq -240(%rbp), %rcx
+    movq %rcx, (%rax)
+    leaq -216(%rbp), %rax
+    movq %rax, -232(%rbp)
+    movq -232(%rbp), %rax
+    movl $0, %ecx
+    movl %ecx, (%rax)
+    leaq -224(%rbp), %rax
+    movq %rax, -232(%rbp)
+    movq -232(%rbp), %rax
+    movl $0, %ecx
+    movl %ecx, (%rax)
+sum_2:
+    leaq -224(%rbp), %rax
+    movq %rax, -232(%rbp)
+    movq -232(%rbp), %rax
+    movl (%rax), %eax
+    movl %eax, -232(%rbp)
+    leaq -184(%rbp), %rax
+    movq %rax, -240(%rbp)
+    movq -240(%rbp), %rax
+    movl (%rax), %eax
+    movl %eax, -240(%rbp)
+    movl -232(%rbp), %eax
+    cmpl -240(%rbp), %eax
+    setl %al
+    movzbl %al, %eax
+    movl %eax, -232(%rbp)
+    movl -232(%rbp), %eax
+    testl %eax, %eax
+    jz sum_7
+sum_3:
+    leaq -216(%rbp), %rax
+    movq %rax, -232(%rbp)
+    leaq -208(%rbp), %rax
+    movq %rax, -240(%rbp)
+    movq -240(%rbp), %rax
+    movl (%rax), %eax
+    movl %eax, -248(%rbp)
+    movl -248(%rbp), %eax
+    cmpl $48, %eax
+    setl %al
+    movzbl %al, %eax
+    movl %eax, -256(%rbp)
+    movl -256(%rbp), %eax
+    testl %eax, %eax
+    jz sum_4
+    movq -240(%rbp), %rax
+    addq $16, %rax
+    movq %rax, -256(%rbp)
+    movq -256(%rbp), %rax
+    movq (%rax), %rax
+    movq %rax, -256(%rbp)
+    movl -256(%rbp), %eax
+    addl -248(%rbp), %eax
+    movl %eax, -256(%rbp)
+    movq -256(%rbp), %rax
+    movl (%rax), %eax
+    movl %eax, -256(%rbp)
+    movl -248(%rbp), %eax
+    addl $8, %eax
+    movl %eax, -248(%rbp)
+    movq -240(%rbp), %rax
+    movl -248(%rbp), %ecx
+    movl %ecx, (%rax)
+    jmp sum_5
+sum_4:
+    movq -240(%rbp), %rax
+    addq $8, %rax
+    movq %rax, -240(%rbp)
+    movq -240(%rbp), %rax
+    movq (%rax), %rax
+    movq %rax, -248(%rbp)
+    movq -248(%rbp), %rax
+    movl (%rax), %eax
+    movl %eax, -264(%rbp)
+    movq -248(%rbp), %rax
+    addq $8, %rax
+    movq %rax, -248(%rbp)
+    movq -240(%rbp), %rax
+    movq -248(%rbp), %rcx
+    movq %rcx, (%rax)
+    movq -264(%rbp), %rax
+    movq %rax, -256(%rbp)
+sum_5:
+    movq -232(%rbp), %rax
+    movl (%rax), %eax
+    movl %eax, -240(%rbp)
+    movl -240(%rbp), %eax
+    addl -256(%rbp), %eax
+    movl %eax, -240(%rbp)
+    movq -232(%rbp), %rax
+    movl -240(%rbp), %ecx
+    movl %ecx, (%rax)
+    jmp sum_6
+sum_6:
+    leaq -224(%rbp), %rax
+    movq %rax, -232(%rbp)
+    movq -232(%rbp), %rax
+    movl (%rax), %eax
+    movl %eax, -240(%rbp)
+    movl -240(%rbp), %eax
+    addl $1, %eax
+    movl %eax, -240(%rbp)
+    movq -232(%rbp), %rax
+    movl -240(%rbp), %ecx
+    movl %ecx, (%rax)
+    jmp sum_2
+sum_7:
+    leaq -216(%rbp), %rax
+    movq %rax, -232(%rbp)
+    movq -232(%rbp), %rax
+    movl (%rax), %eax
+    movl %eax, -232(%rbp)
+    movl -232(%rbp), %eax
+    mov %rbp, %rsp
+    pop %rbp
+    ret
 .global main
 main:
     push %rbp
     mov %rsp, %rbp
-    subq $32, %rsp
+    subq $16, %rsp
 main_0:
-    leaq -8(%rbp), %rax
-    movq %rax, -16(%rbp)
-    leaq .LC0(%rip), %rax
-    movq %rax, -24(%rbp)
-    movq -24(%rbp), %rsi
-    movq -16(%rbp), %rdi
-    mov $2, %rdx
-    call memcpy
-    leaq -8(%rbp), %rax
-    movq %rax, -16(%rbp)
-    movq $0, %rax
-    imulq $1, %rax
-    movq %rax, -24(%rbp)
-    movq -16(%rbp), %rax
-    addq -24(%rbp), %rax
-    movq %rax, -16(%rbp)
-    movq -16(%rbp), %rax
-    movb (%rax), %al
-    movb %al, -16(%rbp)
-    movsbl -16(%rbp), %eax
-    movl %eax, -16(%rbp)
-    movl -16(%rbp), %eax
+    subq $176, %rsp
+    movl $5, %edi
+    movl $1, %esi
+    movl $2, %edx
+    movl $3, %ecx
+    movl $4, %r8d
+    movl $5, %r9d
+    xor %eax, %eax
+    call sum
+    addq $176, %rsp
+    movl %eax, -8(%rbp)
+    movl -8(%rbp), %eax
     mov %rbp, %rsp
     pop %rbp
     ret


### PR DESCRIPTION
Closes #13 